### PR TITLE
Remove Overview from footer and menu

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,11 +84,8 @@ const config = {
             type: 'dropdown',
             position: 'right',
             label: 'Learn',
+            to: 'learn/overview',
             items: [
-              {
-                label: 'Overview',
-                to: 'learn/overview',
-              },
               {
                 label: 'Quickstart',
                 to: 'learn/quickstart',
@@ -154,7 +151,7 @@ const config = {
               },
               {
                 label: 'Learn',
-                to: 'learn/quickstart',
+                to: 'learn/overview',
               },
               {
                 label: 'Projects',
@@ -176,10 +173,6 @@ const config = {
               {
                 label: 'Quickstart',
                 to: 'learn/quickstart',
-              },
-              {
-                label: 'Overview',
-                to: 'learn/overview',
               },
               {
                 label: 'Typed errors',


### PR DESCRIPTION
This PR makes the "Learn" in the menu bar clickable, and removes the link to Overview in both the menu and the footer. This way they are still reachable, but the footer and menu don't look so long.