### PR TITLE
Proposal to link API docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -120,6 +120,11 @@ const config = {
             ],
           },
           {
+            label: 'API Docs',
+            position: 'right',
+            to: 'https://arrow-kt.github.io/arrow/index.html',
+          },
+          {
             type: 'dropdown',
             position: 'right',
             label: 'Incubation',
@@ -211,8 +216,12 @@ const config = {
             ],
           },
           {
-            title: 'Incubation',
+            title: 'More',
             items: [
+              {
+                label: 'API Docs',
+                to: 'https://arrow-kt.github.io/arrow/index.html',
+              },
               {
                 label: 'Analysis',
                 to: 'category/analysis',


### PR DESCRIPTION
We want to have a quick link to the API docs, so that power users can easily find them. This is a proposal which puts a link in the top bar (outside of _Learn_), but feel free to suggest other options.