### PR TITLE
Reorganize header / footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,16 +97,15 @@ const createConfig = async () => {
               activeBaseRegex: '^/+$',
             },
             {
-              to: '/about/what-is-arrow',
-              position: 'right',
-              label: 'About',
-            },
-            {
               type: 'dropdown',
               position: 'right',
               label: 'Learn',
               to: '/learn/overview',
               items: [
+                {
+                  label: 'Overview',
+                  to: '/learn/overview',
+                },
                 {
                   label: 'Quickstart',
                   to: '/learn/quickstart',
@@ -136,12 +135,16 @@ const createConfig = async () => {
                   to: '/learn/design',
                   activeBaseRegex: '^(/learn/design)',
                 },
+                {
+                  label: 'Integrations',
+                  to: '/learn/integrations',
+                },
               ],
             },
             {
               label: 'API Docs',
               position: 'right',
-              to: 'https://arrow-kt.github.io/arrow/index.html',
+              href: 'https://arrow-kt.github.io/arrow/index.html',
             },
             {
               type: 'dropdown',
@@ -184,10 +187,6 @@ const createConfig = async () => {
               title: 'Menu',
               items: [
                 {
-                  label: 'About',
-                  to: '/about/what-is-arrow',
-                },
-                {
                   label: 'Learn',
                   to: '/learn/overview',
                 },
@@ -210,7 +209,7 @@ const createConfig = async () => {
               items: [
                 {
                   label: 'Quickstart',
-                  to: 'learn/quickstart',
+                  to: '/learn/quickstart',
                 },
                 {
                   label: 'Typed errors',
@@ -224,6 +223,11 @@ const createConfig = async () => {
                   label: 'Resilience',
                   to: '/learn/resilience',
                 },
+              ],
+            },
+            {
+              title: 'More',
+              items: [
                 {
                   label: 'Immutable data',
                   to: '/learn/immutable-data',
@@ -232,14 +236,9 @@ const createConfig = async () => {
                   label: 'Design',
                   to: '/learn/design',
                 },
-              ],
-            },
-            {
-              title: 'More',
-              items: [
                 {
-                  label: 'API Docs',
-                  to: 'https://arrow-kt.github.io/arrow/index.html',
+                  label: 'Integrations',
+                  to: '/learn/integrations',
                 },
                 {
                   label: 'Analysis',


### PR DESCRIPTION
This PR changes the contents of the header and footer to look as follows.

_Header_: removal of _About_, and added a "open window" symbol to _API Docs_
![Captura de pantalla 2023-03-22 a las 10 46 26](https://user-images.githubusercontent.com/309334/226864580-840dee1b-c185-4103-9c01-b491bd986714.png)

_Header_: added links to _Overview_ and _Integrations_
![Captura de pantalla 2023-03-22 a las 10 46 45](https://user-images.githubusercontent.com/309334/226864658-8f87a5e7-aec6-4b0d-8f0f-1a1f8ad00862.png)

_Footer_: made all columns the same length by moving some of the items from _Learn_ to _More_, and removed the _About_ item as done in the header
![Captura de pantalla 2023-03-22 a las 10 48 31](https://user-images.githubusercontent.com/309334/226865221-f42bf99e-86dd-403f-a10b-cc9494ad1799.png)
