### PR TITLE
Integrate "Why suspend over IO"

### DIFF
--- a/content/docs/learn/design/suspend-io.md
+++ b/content/docs/learn/design/suspend-io.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 # Why suspend over IO
 
 Other functional ecosystems, Scala and Haskell among others,
-use a monadic model for side effects. The key component of this model
+use a [monadic model for side effects](../../quickstart/from-fp/#computation-blocks). The key component of this model
 is a wrapper called `IO`. Arrow has adopted a different model,
 based on `suspend` and top-level extension functions over
 `suspend () -> A`. This section explains the rationale behind this choice.
@@ -184,6 +184,12 @@ suspend fun <R> R.getProcessedUsers(): Either<PersistenceError, List<ProcessedUs
         where R : Repo,
               R : Persistence = fetchUsers().process()
 ```
+
+:::info Context receivers
+
+[Context receivers](../receivers-flatmap/) offer a nicer approach to composition of layers.
+
+:::
 
 ## Performance
 


### PR DESCRIPTION
This PR brings the _Why suspend over IO_ document, as discussed in https://github.com/arrow-kt/arrow-website/pull/116#discussion_r1151756687. @nomisRev @raulraja please check that everything we say is still relevant.

I've made a few edits, including:
- Disclaimer that the rationale applies to Kotlin + Arrow, it doesn't mean this is the golden standard for everything
![Captura de pantalla 2023-03-30 a las 13 25 56](https://user-images.githubusercontent.com/309334/228821611-f6a69518-dd15-43fb-bb68-3026b11205f0.png)
- Clearly marked conclusions at the end of each section
![Captura de pantalla 2023-03-30 a las 13 26 29](https://user-images.githubusercontent.com/309334/228821718-0732b814-f01d-4f67-ab8a-55d4299df4ee.png)
- Update to the names used in Cats Effect 3.x
![Captura de pantalla 2023-03-30 a las 13 27 47](https://user-images.githubusercontent.com/309334/228821999-cd2bffb4-3eb1-4ef9-8f2b-89949bc536fd.png)
