### PR TITLE
Move to `arrow-resilience`

### DIFF
--- a/content/docs/learn/overview.md
+++ b/content/docs/learn/overview.md
@@ -34,7 +34,7 @@ Each section in the documentation roughly corresponds to one of the libraries th
 | --- | --- |
 | `arrow-core` <br /> _Companion to [Kotlin's standard library](https://kotlinlang.org/api/latest/jvm/stdlib/)_ | [Typed errors](../typed-errors/), including `Raise`, `Either`, and `Option` <br /> [Non-empty collections](../collections-functions/non-empty) <br /> [Utilities for functions](../collections-functions/utils/) and [memoization](../collections-functions/recursive/) |
 | `arrow-fx-coroutines` <br /> _Companion to [KotlinX Coroutines](https://kotlinlang.org/api/kotlinx.coroutines/kotlinx-coroutines-core/)_ | [High-level concurrency](../coroutines/parallel), including `parMap` and `parZip` <br /> [Resource management](../coroutines/resource-safety/) |
-| `arrow-fx-resilience` | [Resilience patterns](../resilience/) |
+| `arrow-resilience` | [Resilience patterns](../resilience/) |
 | `arrow-fx-stm` | [Software Transactional Memory](../coroutines/stm/) (STM) |
 | `arrow-optics` + `arrow-optics-ksp-plugin` <br /> _Companion to [data](https://kotlinlang.org/docs/data-classes.html) and [sealed](https://kotlinlang.org/docs/sealed-classes.html) classes_ | Utilities for [immutable data](../immutable-data/intro/) |
 | `arrow-atomic` <br /> _Multiplatform-ready [references](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.native.concurrent/-atomic-reference/)_ | [Atomic references](../coroutines/concurrency-primitives/#atomic) |

--- a/content/docs/learn/resilience/circuitbreaker.md
+++ b/content/docs/learn/resilience/circuitbreaker.md
@@ -71,13 +71,13 @@ in _Cloud Design Patterns_.
 
 :::
 
-## Arrow's [`CircuitBreaker`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-circuit-breaker/index.html)
+## Arrow's [`CircuitBreaker`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-circuit-breaker/index.html)
 
 Let's create a circuit breaker that only allows us to call a remote service twice.
 After that, whenever more than two requests fail with an exception, 
 the circuit breaker starts short-circuiting/failing-fast.
 
-A new instance of `CircuitBreaker` is created using [`of`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-circuit-breaker/-companion/of.html); there, we specify
+A new instance of `CircuitBreaker` is created using [`of`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-circuit-breaker/-companion/of.html); there, we specify
 the different options. 
 
 :::caution Deprecation in Arrow 1.2
@@ -87,14 +87,14 @@ The `of` constructor function has been deprecated in favor of exposing the `Circ
 :::
 
 Then we wrap every call to the service that may
-potentially fail with [`protectOrThrow`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-circuit-breaker/protect-or-throw.html) or [`protectEither`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-circuit-breaker/protect-either.html), depending on how we
+potentially fail with [`protectOrThrow`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-circuit-breaker/protect-or-throw.html) or [`protectEither`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-circuit-breaker/protect-either.html), depending on how we
 want this error to be communicated back. If the error arises, the internal state
 of the circuit breaker also changes.
 
 <!--- INCLUDE
 import arrow.core.Either
-import arrow.fx.resilience.CircuitBreaker
-import arrow.fx.resilience.CircuitBreaker.OpeningStrategy
+import arrow.resilience.CircuitBreaker
+import arrow.resilience.CircuitBreaker.OpeningStrategy
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.delay
@@ -142,10 +142,10 @@ even different functions to the same resource or service.
 
 <!--- INCLUDE
 import arrow.core.Either
-import arrow.fx.resilience.CircuitBreaker
-import arrow.fx.resilience.CircuitBreaker.OpeningStrategy
-import arrow.fx.resilience.Schedule
-import arrow.fx.resilience.retry
+import arrow.resilience.CircuitBreaker
+import arrow.resilience.CircuitBreaker.OpeningStrategy
+import arrow.resilience.Schedule
+import arrow.resilience.retry
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.delay

--- a/content/docs/learn/resilience/intro.md
+++ b/content/docs/learn/resilience/intro.md
@@ -19,7 +19,7 @@ and composable way.
 :::caution Arrow pre-1.2.0
 
 In Arrow series 1.0.x and 1.1.x, these types were provided as part of the
-`arrow-fx-coroutines` library. They currently live in `arrow-fx-resilience`,
+`arrow-fx-coroutines` library. From 1.2.0 on they live in `arrow-resilience`,
 even though a migration window is in place until Arrow 2.0.
 
 :::

--- a/content/docs/learn/resilience/retry-and-repeat.md
+++ b/content/docs/learn/resilience/retry-and-repeat.md
@@ -19,18 +19,18 @@ in _Cloud Design Patterns_.
 :::
 
 
-[`Schedule`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/index.html)
+[`Schedule`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/index.html)
 allows you to define and compose powerful yet simple policies. There are two
 steps involved in using `Schedule`.
 
 1. First, we need to **construct** a policy, which specifies the amount and the
    delay in repetition.
 2. Then we **run** this schedule with a specified action. There are two ways to do so:
-   - [`retry`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/retry.html)
+   - [`retry`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/retry.html)
      executes the action once, and if it fails, it is reattempted based
      on the scheduling policy. It stops when the action succeeds or when the policy 
      determines it should not be reattempted again.
-   - [`repeat`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/repeat.html)
+   - [`repeat`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/repeat.html)
      executes the action, and if it succeeds, keeps executing it again based on
      the scheduling policy passed as an argument. It stops if the action 
      fails or the policy determines it should not be executed again. 
@@ -45,12 +45,12 @@ steps involved in using `Schedule`.
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
-import arrow.fx.resilience.*
+import arrow.resilience.*
 import io.kotest.matchers.shouldBe
 -->
 
 Scheduling policies are constructed using the methods in [`Schedule`'s
-companion object](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/-companion/index.html).
+companion object](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/-companion/index.html).
 Schedule policies also return values on each step, which can be used to
 take decisions based on previous values.
 
@@ -108,8 +108,8 @@ suspend fun example(): Unit {
 <!--- TEST assert -->
 
 Notice that we did not handle the error case. There are overloads 
-[`repeatOrElse`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/repeat-or-else.html)
-and [`repeatOrElseEither`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/repeat-or-else-either.html)
+[`repeatOrElse`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/repeat-or-else.html)
+and [`repeatOrElseEither`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/repeat-or-else-either.html)
 offering that capability. Repeat will just rethrow any error encountered.
 
 ### Collecting values
@@ -122,9 +122,9 @@ But we have three other possibilities:
 - Keep all intermediate results.
 
 To discard the values provided by the repetition of the action, we combine our 
-policy with [`Schedule.unit`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/-companion/unit.html), 
-using the [`zipLeft`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/zip-left.html)
-or [`zipRight`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/zip-right.html)
+policy with [`Schedule.unit`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/-companion/unit.html), 
+using the [`zipLeft`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/zip-left.html)
+or [`zipRight`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/zip-right.html)
 combinators, which keep just the output of one of the policies:
 
 ```kotlin
@@ -146,7 +146,7 @@ suspend fun example(): Unit {
 <!--- KNIT example-schedule-05.kt -->
 <!--- TEST assert -->
 
-Following the same strategy, we can zip it with the [`Schedule.identity`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/-companion/identity.html) 
+Following the same strategy, we can zip it with the [`Schedule.identity`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/-companion/identity.html) 
 policy to keep only the last result of the action.
 
 ```kotlin
@@ -164,7 +164,7 @@ suspend fun example(): Unit {
 <!--- TEST assert -->
 
 Finally, if we want to keep all intermediate results, we can zip the policy with
-[`Schedule.collect`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/-companion/collect.html).
+[`Schedule.collect`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/-companion/collect.html).
 
 ```kotlin
 suspend fun example(): Unit {
@@ -183,8 +183,8 @@ suspend fun example(): Unit {
 
 ### Until/while it produces a certain value
 
-We can make use of the policies [`doWhile`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/-companion/do-while.html)
-and [`doUntil`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-schedule/-companion/do-until.html) 
+We can make use of the policies [`doWhile`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/-companion/do-while.html)
+and [`doUntil`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-schedule/-companion/do-until.html) 
 to repeat an action while or until its produced result matches a given predicate.
 
 ```kotlin

--- a/content/docs/learn/resilience/saga.md
+++ b/content/docs/learn/resilience/saga.md
@@ -26,12 +26,12 @@ in _Cloud Design Patterns_.
 import io.kotest.matchers.shouldBe
 -->
 
-Arrow Fx Resilience provides the [`saga`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/saga.html)
+Arrow Fx Resilience provides the [`saga`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/saga.html)
 function, which creates a new scope where compensating actions can be declared
 alongside the action to perform. This is done by the [`saga` function in
-`SagaScope`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/-saga-scope/saga.html).
+`SagaScope`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/-saga-scope/saga.html).
 The resulting `Saga<A>` doesn't perform any actions, though; you need to call
-[`transact`](https://arrow-kt.github.io/arrow/arrow-fx-resilience/arrow.fx.resilience/transact.html)
+[`transact`](https://arrow-kt.github.io/arrow/arrow-resilience/arrow.resilience/transact.html)
 to keep the chain going.
 
 Let's use a small counter as an example, which we implement using the
@@ -45,7 +45,7 @@ import arrow.core.left
 
 ```kotlin
 import arrow.atomic.AtomicInt
-import arrow.fx.resilience.*
+import arrow.resilience.*
 
 val INITIAL_VALUE = 1
 

--- a/content/docs/learn/summary.md
+++ b/content/docs/learn/summary.md
@@ -96,7 +96,7 @@ These functions use `NonEmptyList<E>` as the surrounding error type.
 - `Schedule.repeat` to repeat an action, correctly handling problems.
 - `resourceScope` for correct acquisition and release of resources.
 
-For more resilience options check the `arrow-fx-resilience` package.
+For more resilience options check the [corresponding section in the docs](../resilience/).
 
 </details>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ coroutines = "1.6.4"
 kotest = "5.5.5"
 kotlin = "1.8.10"
 knit = "0.4.0"
-arrow = "1.1.6-alpha.79"
+arrow = "1.1.6-alpha.84"
 ksp = "1.8.10-1.0.9"
 suspendapp = "0.4.0"
 kotlinKafka = "0.3.0"
@@ -17,7 +17,7 @@ kotest-runner-junit = { module = "io.kotest:kotest-runner-junit5", version.ref =
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib" }
 arrow-core = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
 arrow-fx-coroutines = { module = "io.arrow-kt:arrow-fx-coroutines", version.ref = "arrow" }
-arrow-fx-resilience = { module = "io.arrow-kt:arrow-fx-resilience", version.ref = "arrow" }
+arrow-resilience = { module = "io.arrow-kt:arrow-resilience", version.ref = "arrow" }
 arrow-fx-stm = { module = "io.arrow-kt:arrow-fx-stm", version.ref = "arrow" }
 arrow-optics = { module = "io.arrow-kt:arrow-optics", version.ref = "arrow" }
 arrow-opticsPlugin = { module = "io.arrow-kt:arrow-optics-ksp-plugin", version.ref = "arrow" }

--- a/guide/build.gradle.kts
+++ b/guide/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
   testImplementation(libs.kotlinx.knit.test)
   testImplementation(libs.arrow.core)
   testImplementation(libs.arrow.fx.coroutines)
-  testImplementation(libs.arrow.fx.resilience)
+  testImplementation(libs.arrow.resilience)
   testImplementation(libs.arrow.fx.stm)
   testImplementation(libs.arrow.optics)
   testImplementation(libs.arrow.opticsReflect)

--- a/guide/src/test/kotlin/examples/example-circuitbreaker-01.kt
+++ b/guide/src/test/kotlin/examples/example-circuitbreaker-01.kt
@@ -2,8 +2,8 @@
 package arrow.website.examples.exampleCircuitbreaker01
 
 import arrow.core.Either
-import arrow.fx.resilience.CircuitBreaker
-import arrow.fx.resilience.CircuitBreaker.OpeningStrategy
+import arrow.resilience.CircuitBreaker
+import arrow.resilience.CircuitBreaker.OpeningStrategy
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.delay

--- a/guide/src/test/kotlin/examples/example-circuitbreaker-02.kt
+++ b/guide/src/test/kotlin/examples/example-circuitbreaker-02.kt
@@ -2,10 +2,10 @@
 package arrow.website.examples.exampleCircuitbreaker02
 
 import arrow.core.Either
-import arrow.fx.resilience.CircuitBreaker
-import arrow.fx.resilience.CircuitBreaker.OpeningStrategy
-import arrow.fx.resilience.Schedule
-import arrow.fx.resilience.retry
+import arrow.resilience.CircuitBreaker
+import arrow.resilience.CircuitBreaker.OpeningStrategy
+import arrow.resilience.Schedule
+import arrow.resilience.retry
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.delay

--- a/guide/src/test/kotlin/examples/example-saga-01.kt
+++ b/guide/src/test/kotlin/examples/example-saga-01.kt
@@ -7,7 +7,7 @@ import arrow.core.Either
 import arrow.core.left
 
 import arrow.atomic.AtomicInt
-import arrow.fx.resilience.*
+import arrow.resilience.*
 
 val INITIAL_VALUE = 1
 

--- a/guide/src/test/kotlin/examples/example-schedule-01.kt
+++ b/guide/src/test/kotlin/examples/example-schedule-01.kt
@@ -4,7 +4,7 @@ package arrow.website.examples.exampleSchedule01
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
-import arrow.fx.resilience.*
+import arrow.resilience.*
 import io.kotest.matchers.shouldBe
 
 fun <A> recurTenTimes() = Schedule.recurs<A>(10)

--- a/guide/src/test/kotlin/examples/example-schedule-02.kt
+++ b/guide/src/test/kotlin/examples/example-schedule-02.kt
@@ -4,7 +4,7 @@ package arrow.website.examples.exampleSchedule02
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
-import arrow.fx.resilience.*
+import arrow.resilience.*
 import io.kotest.matchers.shouldBe
 
 @ExperimentalTime

--- a/guide/src/test/kotlin/examples/example-schedule-03.kt
+++ b/guide/src/test/kotlin/examples/example-schedule-03.kt
@@ -4,7 +4,7 @@ package arrow.website.examples.exampleSchedule03
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
-import arrow.fx.resilience.*
+import arrow.resilience.*
 import io.kotest.matchers.shouldBe
 
 @ExperimentalTime

--- a/guide/src/test/kotlin/examples/example-schedule-04.kt
+++ b/guide/src/test/kotlin/examples/example-schedule-04.kt
@@ -4,7 +4,7 @@ package arrow.website.examples.exampleSchedule04
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
-import arrow.fx.resilience.*
+import arrow.resilience.*
 import io.kotest.matchers.shouldBe
 
 suspend fun example(): Unit {

--- a/guide/src/test/kotlin/examples/example-schedule-05.kt
+++ b/guide/src/test/kotlin/examples/example-schedule-05.kt
@@ -4,7 +4,7 @@ package arrow.website.examples.exampleSchedule05
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
-import arrow.fx.resilience.*
+import arrow.resilience.*
 import io.kotest.matchers.shouldBe
 
 suspend fun example(): Unit {

--- a/guide/src/test/kotlin/examples/example-schedule-06.kt
+++ b/guide/src/test/kotlin/examples/example-schedule-06.kt
@@ -4,7 +4,7 @@ package arrow.website.examples.exampleSchedule06
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
-import arrow.fx.resilience.*
+import arrow.resilience.*
 import io.kotest.matchers.shouldBe
 
 suspend fun example(): Unit {

--- a/guide/src/test/kotlin/examples/example-schedule-07.kt
+++ b/guide/src/test/kotlin/examples/example-schedule-07.kt
@@ -4,7 +4,7 @@ package arrow.website.examples.exampleSchedule07
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
-import arrow.fx.resilience.*
+import arrow.resilience.*
 import io.kotest.matchers.shouldBe
 
 suspend fun example(): Unit {

--- a/guide/src/test/kotlin/examples/example-schedule-08.kt
+++ b/guide/src/test/kotlin/examples/example-schedule-08.kt
@@ -4,7 +4,7 @@ package arrow.website.examples.exampleSchedule08
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
-import arrow.fx.resilience.*
+import arrow.resilience.*
 import io.kotest.matchers.shouldBe
 
 suspend fun example(): Unit {


### PR DESCRIPTION
This PR updates the examples and the documentation to talk about `arrow-resilience` and the `arrow.resilience` package. It also updates Arrow's version, so it closes #127.