### PR TITLE
Change Λrrow occurrences for Arrow

### DIFF
--- a/content/blog/2018-10-05-kotlin-conf-fp-in-kotlin-with-arrow.md
+++ b/content/blog/2018-10-05-kotlin-conf-fp-in-kotlin-with-arrow.md
@@ -1,5 +1,5 @@
 ---
-title: Architecting Typed FP Applications & Libraries in Kotlin with Λrrow
+title: Architecting Typed FP Applications & Libraries in Kotlin with Arrow
 image: https://img.youtube.com/vi/VOZZTSuDMFE/maxresdefault.jpg
 category: videos
 tags: [core, fx, videos]
@@ -7,6 +7,6 @@ link: https://www.youtube.com/watch?v=VOZZTSuDMFE
 event: KotlinConf, Amsterdam
 ---
 
-This talk includes a comprehensive walkthrough of the most important patterns covered by the data types and type classes we find in Λrrow. Each pattern will be accompanied by code examples that illustrate how Λrrow brings Typed Functional Programming to Kotlin.
+This talk includes a comprehensive walkthrough of the most important patterns covered by the data types and type classes we find in Arrow. Each pattern will be accompanied by code examples that illustrate how Arrow brings Typed Functional Programming to Kotlin.
 
 [Sources and slides](https://github.com/47deg/arrow-architecture)

--- a/content/blog/2018-11-24-ank.md
+++ b/content/blog/2018-11-24-ank.md
@@ -1,9 +1,9 @@
 ---
-title: Manual documentation is dead. Long live automated documentation! Automated documentation with ΛNK
+title: Manual documentation is dead. Long live automated documentation! Automated documentation with ANK
 image: https://img.youtube.com/vi/kr8iWE4Jfhc/maxresdefault.jpg
 category: videos
 tags: [core, incubator, videos]
 link: https://www.youtube.com/watch?v=kr8iWE4Jfhc
 event: droidconSF, San Francisco
 ---
-It includes how the ΛNK plugin works: from having a tool that evaluates and verifies your doc snippets at compile time, to generating code documentation that is always correct and up to date.
+It includes how the ANK plugin works: from having a tool that evaluates and verifies your doc snippets at compile time, to generating code documentation that is always correct and up to date.

--- a/content/blog/2020-04-06-template-oriented-programming-talk.md
+++ b/content/blog/2020-04-06-template-oriented-programming-talk.md
@@ -6,4 +6,4 @@ tags: [core, videos]
 link: https://youtu.be/_QBlKtUY6ac
 event: Kotlin User Group, Hyderabad, Online Meetup
 ---
-Learn about the magic of Ad-hoc polymorphism using Λrrow typeclasses with simple examples.
+Learn about the magic of Ad-hoc polymorphism using Arrow typeclasses with simple examples.

--- a/content/docs/learn/quickstart/_category_.json
+++ b/content/docs/learn/quickstart/_category_.json
@@ -3,7 +3,7 @@
   "position": 2,
   "customProps": {
     "icon": "icon-quickstart.svg",
-    "description": "Gradle or Maven, JVM or Multiplatform, Λrrow fits in all your projects",
+    "description": "Gradle or Maven, JVM or Multiplatform, Arrow fits in all your projects",
     "overview": true
   }
 }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ const createConfig = async () => {
 
   /** @type {import('@docusaurus/types').Config} */
   const config = {
-    title: 'Λrrow',
+    title: 'Arrow',
     tagline: 'Idiomatic functional programming for Kotlin',
     favicon: '/img/arrow-brand-icon.svg',
     url: 'https://arrow-kt.io',

--- a/src/pages/community/events/events.yml
+++ b/src/pages/community/events/events.yml
@@ -31,7 +31,7 @@ events:
     body: Lorem ipsum dolor sit amet, consectetur adipiscing elit. In pretium ligula nec mi facilisis malesuada.
 
 banner:
-  title: Want to know more about Λrrow?
+  title: Want to know more about Arrow?
   ctaList:
     - title: Read the docs
       href: /learn/overview

--- a/src/pages/community/support/support.yml
+++ b/src/pages/community/support/support.yml
@@ -38,7 +38,7 @@ links:
 
 
 banner:
-  title: Want to know more about Λrrow?
+  title: Want to know more about Arrow?
   ctaList:
     - title: Read the docs
       href: /learn/overview

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -29,7 +29,7 @@ export default function Home(): JSX.Element {
           className={`container text--center ${styles.textContainer} ${styles.verticalRhythm}`}>
           <h1>Start learning now</h1>
           <p>
-            Λrrow is composed of different libraries that greatly improve your
+            Arrow is composed of different libraries that greatly improve your
             developer experience using Kotlin
           </p>
         </section>
@@ -41,7 +41,7 @@ export default function Home(): JSX.Element {
         </section>
 {/*         <section */}
 {/*           className={`container text--center ${styles.textContainer} ${styles.verticalRhythm}`}> */}
-{/*           <h1>What can Λrrow do</h1> */}
+{/*           <h1>What can Arrow do</h1> */}
 {/*           <p> */}
 {/*             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu */}
 {/*             turpis molestie, dictum est */}

--- a/src/pages/index.yml
+++ b/src/pages/index.yml
@@ -1,7 +1,7 @@
 hero:
-  title: Λrrow brings idiomatic <u>functional programming</u> to Kotlin
+  title: Arrow brings idiomatic <u>functional programming</u> to Kotlin
   ctaList:
-    - title: What is Λrrow
+    - title: What is Arrow
       href: /learn/overview
 
     - title: Get Started
@@ -11,7 +11,7 @@ features:
   - title: Quickstart
     href: /learn/quickstart
     icon: icon-quickstart.svg
-    body: Gradle or Maven, JVM or Multiplatform, Λrrow fits in all your projects
+    body: Gradle or Maven, JVM or Multiplatform, Arrow fits in all your projects
 
   - title: Typed errors
     href: /learn/typed-errors

--- a/src/pages/libraries/libraries.yml
+++ b/src/pages/libraries/libraries.yml
@@ -81,7 +81,7 @@ navs:
 #    body: Lorem ipsum dolor sit amet, consectetur adipiscing eliorem ipsum dolor sit amet
 
 banner:
-  title: Want to know more about Λrrow?
+  title: Want to know more about Arrow?
   ctaList:
     - title: Read the docs
       href: /learn/overview

--- a/src/pages/training/training.tsx
+++ b/src/pages/training/training.tsx
@@ -32,9 +32,9 @@ export default function Training(): JSX.Element {
       <main>
         <section
           className={`container text--center ${styles.textContainer} ${styles.verticalRhythm}`}>
-          <h1>Learn with Λrrow</h1>
+          <h1>Learn with Arrow</h1>
           <p>
-            Λrrow is composed of different libraries that greatly improve your
+            Arrow is composed of different libraries that greatly improve your
             developer experience using Kotlin
           </p>
         </section>
@@ -48,7 +48,7 @@ export default function Training(): JSX.Element {
           className={`container text--center ${styles.textContainer} ${styles.verticalRhythm}`}>
           <h1>Start learning now</h1>
           <p>
-            Λrrow is composed of different libraries that greatly improve your
+            Arrow is composed of different libraries that greatly improve your
             developer experience using Kotlin
           </p>
         </section>

--- a/src/pages/training/training.yml
+++ b/src/pages/training/training.yml
@@ -63,7 +63,7 @@ navs:
     body: Lorem ipsum dolor sit amet, consectetur adipiscing eliorem ipsum dolor sit amet
 
 banner:
-  title: Want to know more about Λrrow?
+  title: Want to know more about Arrow?
   ctaList:
     - title: Read the docs
       href: /learn/overview


### PR DESCRIPTION
This PR modifies all occurrences of referring to the library name as `Λrrow` for its proper name: `Arrow`.

While the usage of the uppercase lambda is cool, and it creates a nice effect on the text, it totally defeats the purpose of having accessible web content. And it also brings some inconsistencies and problems when writing the library on different media, etc. It also creates the issue of the library name not being properly indexed by web crawlers and bots.

While some possible bypass for those problems could be the use of the [`aria-label` property](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label), it would really be a hacky shortcut misusing it, as [that wouldn't be the goal of that HTML property](https://auroratide.com/posts/how-to-not-use-aria-label). And all this while not really solving the underlying issue of having an improper library name.

The usage of the uppercased lambda name, `Λrrow,` should only be used on display media like images, videos, and such, but never text content.