### PR TITLE
Add CNAME file to the static folder

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+arrow-kt.io


### PR DESCRIPTION
We build the Arrow website with a custom domain and host it with GitHub Pages. The problem arises every time we publish a new release because the CNAME file gets deleted, so the site is not accessible through the arrow-kt.io URL. 

This pull request adds the CNAME file to the static folder to avoid this issue.

It fixes #149 