### PR TITLE
Change Arrow version to 1.2.0-RC

### DIFF
--- a/content/docs/learn/quickstart/index.md
+++ b/content/docs/learn/quickstart/index.md
@@ -71,8 +71,8 @@ Simply include the desired library in your `dependencies` block or as a
 
 ```kotlin
 dependencies {
-  implementation("io.arrow-kt:arrow-core:1.2.0")
-  implementation("io.arrow-kt:arrow-fx-coroutines:1.2.0")
+  implementation("io.arrow-kt:arrow-core:1.2.0-RC")
+  implementation("io.arrow-kt:arrow-fx-coroutines:1.2.0-RC")
 }
 ```
 
@@ -81,8 +81,8 @@ dependencies {
 
 ```groovy
 dependencies {
-  implementation 'io.arrow-kt:arrow-core:1.2.0'
-  implementation 'io.arrow-kt:arrow-fx-coroutines:1.2.0'
+  implementation 'io.arrow-kt:arrow-core:1.2.0-RC'
+  implementation 'io.arrow-kt:arrow-fx-coroutines:1.2.0-RC'
 }
 ```
 
@@ -94,12 +94,12 @@ dependencies {
 <dependency>
   <groupId>io.arrow-kt</groupId>
   <artifactId>arrow-core</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.0-RC</version>
 </dependency>
 <dependency>
   <groupId>io.arrow-kt</groupId>
   <artifactId>arrow-fx-coroutines</artifactId>
-  <version>1.2.0</version>
+  <version>1.2.0-RC</version>
 </dependency>
 ```
 
@@ -118,7 +118,7 @@ your Gradle build has several subprojects.
 
 ```yaml
 [versions]
-arrow = "1.2.0"
+arrow = "1.2.0-RC"
 # other versions
 
 [libraries]
@@ -172,7 +172,7 @@ to include `arrow-stack`, which declares versions for the rest of the components
 
 ```kotlin
 dependencies {
-  implementation(platform("io.arrow-kt:arrow-stack:1.2.0"))
+  implementation(platform("io.arrow-kt:arrow-stack:1.2.0-RC"))
   // no versions on libraries
   implementation("io.arrow-kt:arrow-core")
   implementation("io.arrow-kt:arrow-fx-coroutines")
@@ -184,7 +184,7 @@ dependencies {
 
 ```groovy
 dependencies {
-  implementation platform('io.arrow-kt:arrow-stack:1.2.0')
+  implementation platform('io.arrow-kt:arrow-stack:1.2.0-RC')
   // no versions on libraries
   implementation 'io.arrow-kt:arrow-core'
   implementation 'io.arrow-kt:arrow-fx-coroutines'
@@ -199,7 +199,7 @@ dependencies {
 <dependency>
     <groupId>io.arrow-kt</groupId>
     <artifactId>arrow-stack</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.0-RC</version>
     <type>pom</type>
     <scope>import</scope>
 </dependency>
@@ -234,8 +234,8 @@ plugins {
 }
 
 dependencies {
-  implementation("io.arrow-kt:arrow-optics:1.2.0")
-  ksp("io.arrow-kt:arrow-optics-ksp-plugin:1.2.0")
+  implementation("io.arrow-kt:arrow-optics:1.2.0-RC")
+  ksp("io.arrow-kt:arrow-optics-ksp-plugin:1.2.0-RC")
 }
 ```
 
@@ -248,8 +248,8 @@ plugins {
 }
 
 dependencies {
-  implementation 'io.arrow-kt:arrow-optics:1.2.0'
-  ksp 'io.arrow-kt:arrow-optics-ksp-plugin:1.2.0'
+  implementation 'io.arrow-kt:arrow-optics:1.2.0-RC'
+  ksp 'io.arrow-kt:arrow-optics-ksp-plugin:1.2.0-RC'
 }
 ```
 


### PR DESCRIPTION
The `Quickstart` section shows how to add the Arrow dependencies to a project. However, it points out an existing version (`1.2.0`). This pull request changes the Arrow version to `1.2.0-RC`