### PR TITLE
Add canonical attribute to cross posted docs

### DIFF
--- a/content/docs/learn/design/domain-modeling.md
+++ b/content/docs/learn/design/domain-modeling.md
@@ -1,8 +1,11 @@
 ---
+title: Domain modeling
 sidebar_position: 1
 ---
 
-# Domain modeling
+<head>
+  <link rel="canonical" href="https://www.47deg.com/blog/functional-domain-modeling/" />
+</head>
 
 :::note This article was originally published in the [47 Degrees blog](https://www.47deg.com/blog/functional-domain-modeling/).
 

--- a/content/docs/learn/design/effects-contexts.md
+++ b/content/docs/learn/design/effects-contexts.md
@@ -1,8 +1,11 @@
 ---
+title: Effects and contexts
 sidebar_position: 2
 ---
 
-# Effects and contexts
+<head>
+  <link rel="canonical" href="https://www.47deg.com/blog/effects-contexts/" />
+</head>
 
 :::note This article was originally published in the [47 Degrees blog](https://www.47deg.com/blog/effects-contexts/).
 

--- a/content/docs/learn/design/receivers-flatmap.md
+++ b/content/docs/learn/design/receivers-flatmap.md
@@ -1,8 +1,11 @@
 ---
+title: Receivers vs. flatMap
 sidebar_position: 3
 ---
 
-# Receivers vs. flatMap
+<head>
+  <link rel="canonical" href="https://xebia.com/blog/the-suspend-receivers-style-in-kotlin/" />
+</head>
 
 :::note This article was originally published at [Xebia's blog](https://xebia.com/blog/the-suspend-receivers-style-in-kotlin/). 
 


### PR DESCRIPTION
### Description

When publishing cross posted content, it is important to help search engines identifying where is the canonical document, to avoid those bots marking some content as duplicated, along with them being able to prioritize one above others.

More info in:

https://dev.to/nfrankel/the-importance-of-relcanonical-for-content-writers-4o8f
https://moz.com/learn/seo/canonicalization
https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#canonical
