### PR TITLE
Improvements to typed errors docs

### DIFF
--- a/content/docs/learn/typed-errors/either_ior.md
+++ b/content/docs/learn/typed-errors/either_ior.md
@@ -72,8 +72,8 @@ or `Ior`.
 
 ```mermaid
 graph LR;
-  raise{{"Raise<E>.() -> A"}};
-  other{{"Either<E, A> / Ior<E, A>"}};
+  raise{{"Raise&lt;E&gt;.() -> A"}};
+  other{{"Either&lt;E, A&gt; / Ior&lt;E, A&gt;"}};
   raise-->|either / ior|other;
   other-->|".bind()"|raise;
 ```

--- a/content/docs/learn/typed-errors/own-error-types.md
+++ b/content/docs/learn/typed-errors/own-error-types.md
@@ -1,0 +1,145 @@
+---
+description: Writing your own DSLs with Raise.
+sidebar_position: 5
+---
+
+# Creating your own error wrappers
+
+`Raise` is a powerful tool that allows us to create our own DSLs to raise typed errors.
+It easily allows integration with existing libraries and frameworks that offer similar data types like `Either` or even your own custom types.
+For example, let's take a popular ADT often used in the front end, a type that models `Loading`, `Content`, or `Failure`, often abbreviated as `LCE`.
+
+<!--- INCLUDE
+import arrow.core.raise.Raise
+import arrow.core.raise.ensure
+import arrow.core.raise.recover
+import io.kotest.matchers.shouldBe
+import kotlin.experimental.ExperimentalTypeInference
+-->
+```kotlin
+sealed interface Lce<out E, out A> {
+  object Loading : Lce<Nothing, Nothing>
+  data class Content<A>(val value: A) : Lce<Nothing, A>
+  data class Failure<E>(val error: E) : Lce<E, Nothing>
+}
+```
+
+## Basic functionality
+
+Let's say that once a `Failure` or `Loading` case is encountered, we want to short-circuit and not continue with the computation.
+It's easy to define a `Raise` instance for `Lce` that does just that. We'll use the composition pattern to do this **without** context receivers.
+Since we need to _raise_ both `Lce.Loading` and `Lce.Failure`, our `Raise` instance will need to be able to `raise` `Lce<E, Nothing>`, and we wrap that in a `LceRaise` class.
+Within that class, a `bind` function can be defined to short-circuit any encountered `Failure` or `Loading` case or otherwise return the `Content` value.
+
+```kotlin
+@JvmInline
+value class LceRaise<E>(val raise: Raise<Lce<E, Nothing>>) : Raise<Lce<E, Nothing>> by raise {
+  fun <A> Lce<E, A>.bind(): A =  when (this) {
+    is Lce.Content -> value
+    is Lce.Failure -> raise.raise(this)
+    Lce.Loading -> raise.raise(Lce.Loading)
+  }
+}
+```
+
+All that is required now is a DSL function. We can use the `recover` or `fold` function to summon an instance of `RaiseLce<E, Nothing>` from the `Raise` type class.
+We wrap the `block` in an `Lce.Content` value and return any encountered `Lce<E, Nothing>` value. We can call `block` by wrapping `Raise<Lce<E, Nothing>>` in `LceRaise`.
+
+```kotlin
+@OptIn(ExperimentalTypeInference::class)
+inline fun <E, A> lce(@BuilderInference block: LceRaise<E>.() -> A): Lce<E, A> =
+  recover({ Lce.Content(block(LceRaise(this))) }) { e: Lce<E, Nothing> -> e }
+```
+
+We can now use this DSL to compose our computations and `Lce` values in the same way as we've discussed above in this document.
+Furthermore, since this DSL is built on top of `Raise`, we can use all the functions we've discussed above.
+
+```kotlin
+fun example() {
+  lce {
+    val a = Lce.Content(1).bind()
+    val b = Lce.Content(1).bind()
+    a + b
+  } shouldBe Lce.Content(2)
+
+  lce {
+    val a = Lce.Content(1).bind()
+    ensure(a > 1) { Lce.Failure("a is not greater than 1") }
+    a + 1
+  } shouldBe Lce.Failure("a is not greater than 1")
+}
+```
+<!--- KNIT example-typed-errors-16.kt -->
+<!--- TEST assert -->
+
+If we'd used _context receivers_, defining this DSL would be even more straightforward, and we could use the `Raise` type class directly.
+
+```kotlin
+context(Raise<Lce<E, Nothing>>)
+fun <E, A> Lce<E, A>.bind(): A =  when (this) {
+  is Lce.Content -> value
+  is Lce.Failure -> raise(this)
+  Lce.Loading -> raise(Lce.Loading)
+}
+
+inline fun <E, A> lce(@BuilderInference block: Raise<Lce<E, Nothing>>.() -> A): Lce<E, A> =
+  recover({ Lce.Content(block(this)) }) { e: Lce<E, Nothing> -> e }
+```
+
+## Reflections on `Failure`
+
+The reason to choose `Lce<E, Nothing>` as type for `Failure` allows for a DSL that has multiple errors.
+Let's consider now a type similar to `Lce`, but with additional states which are not considered success.
+
+```kotlin
+DialogResult<out T>
+ ├ Positive<out T>(value: T) : DialogResult<T>
+ ├ Neutral : DialogResult<Nothing>
+ ├ Negative : DialogResult<Nothing>
+ └ Cancelled: DialogResult<Nothing>
+```
+
+We can now not really conveniently provide `Raise` over the _flat_ type `DialogResult`, and are kind-of forced to use `DialogResult<Nothing>`. However, if we stratify our type differently,
+
+```kotlin
+DialogResult<out T>
+ ├ Positive<out T>(value: T) : DialogResult<T>
+ └ Error : DialogResult<Nothing>
+    ├ Neutral : Error
+    ├ Negative : Error
+    └ Cancelled: Error
+```
+
+We can again benefit from `Raise<DialogResult.Error>`, and the reason that this is **much** more desirable, it that you can now also interop with `Either`!
+
+```kotlin
+dialogResult {
+  val x: DialogResult.Positive(1).bind()
+  val y: Int = DialogResult.Error.left().bind()
+  x + y
+}
+```
+
+That can be useful if you need to for example want to _accumulate errors_, you can now benefit from the default behavior in Kotlin.
+
+```kotlin
+fun dialog(int: Int): DialogResult<Int> =
+  if(int % 2 == 0) DialogResult.Positive(it) else Dialog.Neutral
+
+val res: Either<NonEmptyList<DialogResult.Error>, NonEmptyList<Int>> =
+  listOf(1, 2, 3).mapOrAccumulate { i: Int ->
+    dialog(it).getOrElse { raise(it) }
+  }
+
+dialogResult {
+  res.mapLeft { ... }.bind()
+}
+```
+
+:::info Further discussion
+
+This section was created as a response to
+[this issue in our repository](https://github.com/arrow-kt/arrow-website/issues/161).
+Let's create great docs for Arrow together!
+
+:::

--- a/content/docs/learn/typed-errors/own-error-types.md
+++ b/content/docs/learn/typed-errors/own-error-types.md
@@ -5,6 +5,8 @@ sidebar_position: 5
 
 # Creating your own error wrappers
 
+<!--- TEST_NAME OwnErrorsTest -->
+
 `Raise` is a powerful tool that allows us to create our own DSLs to raise typed errors.
 It easily allows integration with existing libraries and frameworks that offer similar data types like `Either` or even your own custom types.
 For example, let's take a popular ADT often used in the front end, a type that models `Loading`, `Content`, or `Failure`, often abbreviated as `LCE`.
@@ -69,7 +71,7 @@ fun example() {
   } shouldBe Lce.Failure("a is not greater than 1")
 }
 ```
-<!--- KNIT example-typed-errors-16.kt -->
+<!--- KNIT example-own-errors-01.kt -->
 <!--- TEST assert -->
 
 If we'd used _context receivers_, defining this DSL would be even more straightforward, and we could use the `Raise` type class directly.

--- a/content/docs/learn/typed-errors/working-with-typed-errors.md
+++ b/content/docs/learn/typed-errors/working-with-typed-errors.md
@@ -18,6 +18,7 @@ leading to a defensive mode of error handling.
 - [_Functional Error Handling - A Practical Approach_](https://kotlindevday.com/videos/functional-error-handling-a-practical-approach-bas-de-groot/) by Bas de Groot
 - [_Exception handling in Kotlin with Arrow_](https://www.youtube.com/watch?v=ipF540mBG9w) by Ramandeep Kaur
 - [_Por qué no uso excepciones en mi código_](https://www.youtube.com/watch?v=8WdprhzmQe4) by Raúl Raja and [Codely](https://codely.com/)
+- [_Typed error handling in Kotlin_](https://medium.com/@mitchellyuwono/typed-error-handling-in-kotlin-11ff25882880) by Mitchell Yuwono
 
 :::
 
@@ -30,8 +31,9 @@ In the rest of the documentation we often refer to a few concepts related to err
 We use the term _logical failure_ to describe a situation not deemed as successful in your domain, but that it's still within the realms of that domain.
 For example, if you are implementing a repository for users, not finding a user for a certain query is a logical failure.
 
-In contrast to logical failures we have _real exceptions_, which are problems, usually technical, which do not fit in the domain.
-For example, if the connection to the database suddenly drops, or the connection credentials are wrong.
+In contrast to logical failures we have _real exceptions_, which are problems, usually technical, which are _truly exceptional_ and are thus not part of our domain.
+For example, if the connection to the database suddenly drops, or network times out, host unavailable, etcetera.
+Those cases benefit from the [resilience mechanisms](../../resilience/) provided by Arrow.
 
 :::
 
@@ -63,11 +65,11 @@ as their first type parameter.
 
 | Type | Failure | Simultaneous <br /> success and failure? | Kotlin stdlib. or Arrow? |
 |---|---------|------|---|
-| `A?` | No information | | <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/Kotlin_Icon_2021.svg" style={{height: '20px'}} /> |
-| `Option<A>` | No information | | <img src="/img/arrow-brand-icon.svg" style={{height: '20px'}} /> |
-| `Result<A>` | Of type `Throwable`, <br /> inspection possible at runtime | | <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/Kotlin_Icon_2021.svg" style={{height: '20px'}} /> |
-| `Either<E, A>` | Of generic type `E` | | <img src="/img/arrow-brand-icon.svg" style={{height: '20px'}} /> |
-| `Ior<E, A>` | Of generic type `E` | ✔️ | <img src="/img/arrow-brand-icon.svg" style={{height: '20px'}} /> |
+| `A?` | `null` | No | <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/Kotlin_Icon_2021.svg" style={{height: '20px'}} /> |
+| `Option<A>` | `None` | No | <img src="/img/arrow-brand-icon.svg" style={{height: '20px'}} /> |
+| `Result<A>` | `Failure` contains a `Throwable`, <br /> inspection possible at runtime | No | <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/Kotlin_Icon_2021.svg" style={{height: '20px'}} /> |
+| `Either<E, A>` | `Left` contains value of type `E` | No | <img src="/img/arrow-brand-icon.svg" style={{height: '20px'}} /> |
+| `Ior<E, A>` | `Left` contains value of type `E` | Yes, using `Both` | <img src="/img/arrow-brand-icon.svg" style={{height: '20px'}} /> |
 
 
 The second approach is describing errors as part of the _computation context_ of the function.

--- a/content/docs/learn/typed-errors/working-with-typed-errors.md
+++ b/content/docs/learn/typed-errors/working-with-typed-errors.md
@@ -64,7 +64,7 @@ as their first type parameter.
 | Type | Failure | Simultaneous <br /> success and failure? | Kotlin stdlib. or Arrow? |
 |---|---------|------|---|
 | `A?` | No information | | <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/Kotlin_Icon_2021.svg" style={{height: '20px'}} /> |
-| `Option<A>` | No information | | <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/Kotlin_Icon_2021.svg" style={{height: '20px'}} /> |
+| `Option<A>` | No information | | <img src="/img/arrow-brand-icon.svg" style={{height: '20px'}} /> |
 | `Result<A>` | Of type `Throwable`, <br /> inspection possible at runtime | | <img src="https://upload.wikimedia.org/wikipedia/commons/3/37/Kotlin_Icon_2021.svg" style={{height: '20px'}} /> |
 | `Either<E, A>` | Of generic type `E` | | <img src="/img/arrow-brand-icon.svg" style={{height: '20px'}} /> |
 | `Ior<E, A>` | Of generic type `E` | ✔️ | <img src="/img/arrow-brand-icon.svg" style={{height: '20px'}} /> |

--- a/guide/src/test/kotlin/examples/example-own-errors-01.kt
+++ b/guide/src/test/kotlin/examples/example-own-errors-01.kt
@@ -1,5 +1,5 @@
-// This file was automatically generated from working-with-typed-errors.md by Knit tool. Do not edit.
-package arrow.website.examples.exampleTypedErrors16
+// This file was automatically generated from own-error-types.md by Knit tool. Do not edit.
+package arrow.website.examples.exampleOwnErrors01
 
 import arrow.core.raise.Raise
 import arrow.core.raise.ensure

--- a/guide/src/test/kotlin/examples/example-typed-errors-01.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-01.kt
@@ -17,20 +17,3 @@ data class User(val id: Long)
 val user: Either<UserNotFound, User> = User(1).right()
 
 fun Raise<UserNotFound>.user(): User = User(1)
-
-val res = either { user() }
-
-fun Raise<UserNotFound>.res(): User = user.bind()
-
-fun example() {
-  when (res) {
-    is Left -> fail("No logical failure occurred!")
-    is Right -> res.value shouldBe User(1)
-  }
-
-  fold(
-    block = { res() },
-    recover = { _: UserNotFound -> fail("No logical failure occurred!") },
-    transform = { i: User -> i shouldBe User(1) }
-  )
-}

--- a/guide/src/test/kotlin/examples/example-typed-errors-02.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-02.kt
@@ -16,16 +16,3 @@ data class User(val id: Long)
 val error: Either<UserNotFound, User> = UserNotFound.left()
 
 fun Raise<UserNotFound>.error(): User = raise(UserNotFound)
-
-fun example() {
-  when (error) {
-    is Left -> error.value shouldBe UserNotFound
-    is Right -> fail("A logical failure occurred!")
-  }
-
-  fold(
-    { error() },
-    { e: UserNotFound -> e shouldBe UserNotFound },
-    { _: User -> fail("A logical failure occurred!") }
-  )
-}

--- a/guide/src/test/kotlin/examples/example-typed-errors-06.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-06.kt
@@ -2,18 +2,30 @@
 package arrow.website.examples.exampleTypedErrors06
 
 import arrow.core.Either
-import arrow.core.raise.either
-import arrow.core.raise.nullable
+import arrow.core.Either.Left
+import arrow.core.Either.Right
+import arrow.core.left
+import arrow.core.raise.Raise
+import arrow.core.raise.fold
+import io.kotest.assertions.fail
+import io.kotest.matchers.shouldBe
 
-object Problem
+object UserNotFound
+data class User(val id: Long)
 
-fun problematic(n: Int): Either<Problem, Int?> =
-  either { 
-    nullable { 
-      when {
-        n < 0  -> raise(Problem)
-        n == 0 -> raise(null)
-        else   -> n
-      }
-    }
+val error: Either<UserNotFound, User> = UserNotFound.left()
+
+fun Raise<UserNotFound>.error(): User = raise(UserNotFound)
+
+fun example() {
+  when (error) {
+    is Left -> error.value shouldBe UserNotFound
+    is Right -> fail("A logical failure occurred!")
   }
+
+  fold(
+    block = { error() },
+    recover = { e: UserNotFound -> e shouldBe UserNotFound },
+    transform = { _: User -> fail("A logical failure occurred!") }
+  )
+}

--- a/guide/src/test/kotlin/examples/example-typed-errors-07.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-07.kt
@@ -2,33 +2,22 @@
 package arrow.website.examples.exampleTypedErrors07
 
 import arrow.core.Either
+import arrow.core.Either.Left
+import arrow.core.Either.Right
 import arrow.core.left
-import arrow.core.getOrElse
-import arrow.core.raise.ensure
-import arrow.core.raise.either
 import arrow.core.raise.Raise
-import arrow.core.raise.recover
+import arrow.core.raise.fold
+import arrow.core.raise.either
 import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
 
+object UserNotFound
 data class User(val id: Long)
-data class UserNotFound(val message: String)
 
-suspend fun fetchUser(id: Long): Either<UserNotFound, User> = either {
-  ensure(id > 0) { UserNotFound("Invalid id: $id") }
-  User(id)
-}
+val error: Either<UserNotFound, User> = UserNotFound.left()
 
-suspend fun Raise<UserNotFound>.fetchUser(id: Long): User {
-  ensure(id > 0) { UserNotFound("Invalid id: $id") }
-  return User(id)
-}
+fun Raise<UserNotFound>.error(): User = raise(UserNotFound)
 
-suspend fun example() {
-  fetchUser(-1)
-    .getOrElse { e: UserNotFound -> null } shouldBe null
-
-  recover({
-    fetchUser(1)
-  }) { e: UserNotFound -> null } shouldBe User(1)
+fun example() {
+  either { error() } shouldBe UserNotFound.left()
 }

--- a/guide/src/test/kotlin/examples/example-typed-errors-08.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-08.kt
@@ -2,36 +2,20 @@
 package arrow.website.examples.exampleTypedErrors08
 
 import arrow.core.Either
-import arrow.core.left
+import arrow.core.Either.Left
+import arrow.core.Either.Right
+import arrow.core.right
 import arrow.core.raise.Raise
 import arrow.core.raise.either
-import arrow.core.raise.ensure
-import arrow.core.recover
-import arrow.core.right
+import arrow.core.raise.fold
+import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
 
+object UserNotFound
 data class User(val id: Long)
-data class UserNotFound(val message: String)
 
-fun fetchUser(id: Long): Either<UserNotFound, User> = either {
-  ensure(id > 0) { UserNotFound("Invalid id: $id") }
-  User(id)
-}
+val user: Either<UserNotFound, User> = User(1).right()
 
-fun Raise<UserNotFound>.fetchUser(id: Long): User {
-  ensure(id > 0) { UserNotFound("Invalid id: $id") }
-  return User(id)
-}
+fun Raise<UserNotFound>.user(): User = User(1)
 
-object OtherError
-
-fun example() {
-  val either: Either<OtherError, User> =
-    fetchUser(1)
-      .recover { _: UserNotFound -> raise(OtherError) }
-  
-  either shouldBe User(1).right()
-
-  fetchUser(-1)
-    .recover { _: UserNotFound -> raise(OtherError) } shouldBe OtherError.left()
-}
+fun Raise<UserNotFound>.res(): User = user.bind()

--- a/guide/src/test/kotlin/examples/example-typed-errors-09.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-09.kt
@@ -1,21 +1,21 @@
 // This file was automatically generated from working-with-typed-errors.md by Knit tool. Do not edit.
 package arrow.website.examples.exampleTypedErrors09
 
+import arrow.core.Either
+import arrow.core.Either.Left
+import arrow.core.Either.Right
+import arrow.core.right
 import arrow.core.raise.Raise
-import arrow.core.raise.ensure
-import arrow.core.raise.recover
+import arrow.core.raise.either
+import arrow.core.raise.fold
+import io.kotest.assertions.fail
+import io.kotest.matchers.shouldBe
 
-data class User(val id: Long)
-data class UserNotFound(val message: String)
+object Problem
 
-suspend fun Raise<UserNotFound>.fetchUser(id: Long): User {
-  ensure(id > 0) { UserNotFound("Invalid id: $id") }
-  return User(id)
+val maybeTwo: Either<Problem, Int> = either { 2 }
+val maybeFive: Either<Problem, Int> = either { raise(Problem) }
+
+val maybeSeven: Either<Problem, Int> = either {
+  maybeTwo.bind() + maybeFive.bind()
 }
-
-object OtherError
-
-suspend fun Raise<OtherError>.recovery(): User =
-  recover({
-    fetchUser(-1)
-  }) { _: UserNotFound -> raise(OtherError) }

--- a/guide/src/test/kotlin/examples/example-typed-errors-10.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-10.kt
@@ -2,30 +2,18 @@
 package arrow.website.examples.exampleTypedErrors10
 
 import arrow.core.Either
-import arrow.core.raise.catch
-import arrow.core.raise.Raise
-import java.sql.SQLException
+import arrow.core.raise.either
+import arrow.core.raise.nullable
 
-object UsersQueries {
-  fun insert(username: String, email: String): Long = 1L
-}
+object Problem
 
-fun SQLException.isUniqueViolation(): Boolean = true
-
-data class UserAlreadyExists(val username: String, val email: String)
-
-suspend fun Raise<UserAlreadyExists>.insertUser(username: String, email: String): Long =
-  catch({
-    UsersQueries.insert(username, email)
-  }) { e: SQLException ->
-    if (e.isUniqueViolation()) raise(UserAlreadyExists(username, email))
-    else throw e
-  }
-
-suspend fun insertUser(username: String, email: String): Either<UserAlreadyExists, Long> =
-  Either.catchOrThrow<SQLException, Long> {
-    UsersQueries.insert(username, email)
-  }.mapLeft { e ->
-    if (e.isUniqueViolation()) UserAlreadyExists(username, email)
-    else throw e
+fun problematic(n: Int): Either<Problem, Int?> =
+  either { 
+    nullable { 
+      when {
+        n < 0  -> raise(Problem)
+        n == 0 -> raise(null)
+        else   -> n
+      }
+    }
   }

--- a/guide/src/test/kotlin/examples/example-typed-errors-11.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-11.kt
@@ -3,24 +3,32 @@ package arrow.website.examples.exampleTypedErrors11
 
 import arrow.core.Either
 import arrow.core.left
-import arrow.core.nonEmptyListOf
-import arrow.core.mapOrAccumulate
-import arrow.core.raise.either
+import arrow.core.getOrElse
 import arrow.core.raise.ensure
+import arrow.core.raise.either
 import arrow.core.raise.Raise
+import arrow.core.raise.recover
+import io.kotest.assertions.fail
 import io.kotest.matchers.shouldBe
 
-data class NotEven(val i: Int)
+data class User(val id: Long)
+data class UserNotFound(val message: String)
 
-fun Raise<NotEven>.isEven(i: Int): Int =
-  i.also { ensure(i % 2 == 0) { NotEven(i) } }
+suspend fun fetchUser(id: Long): Either<UserNotFound, User> = either {
+  ensure(id > 0) { UserNotFound("Invalid id: $id") }
+  User(id)
+}
 
-fun isEven2(i: Int): Either<NotEven, Int> =
-  either { isEven(i) }
+suspend fun Raise<UserNotFound>.fetchUser(id: Long): User {
+  ensure(id > 0) { UserNotFound("Invalid id: $id") }
+  return User(id)
+}
 
-val errors = nonEmptyListOf(NotEven(1), NotEven(3), NotEven(5), NotEven(7), NotEven(9)).left()
+suspend fun example() {
+  fetchUser(-1)
+    .getOrElse { e: UserNotFound -> null } shouldBe null
 
-fun example() {
-  (1..10).mapOrAccumulate { isEven(it) } shouldBe errors
-  (1..10).mapOrAccumulate { isEven2(it).bind() } shouldBe errors
+  recover({
+    fetchUser(1)
+  }) { e: UserNotFound -> null } shouldBe User(1)
 }

--- a/guide/src/test/kotlin/examples/example-typed-errors-13.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-13.kt
@@ -1,4 +1,21 @@
 // This file was automatically generated from working-with-typed-errors.md by Knit tool. Do not edit.
 package arrow.website.examples.exampleTypedErrors13
 
-data class User(val name: String, val age: Int)
+import arrow.core.raise.Raise
+import arrow.core.raise.ensure
+import arrow.core.raise.recover
+
+data class User(val id: Long)
+data class UserNotFound(val message: String)
+
+suspend fun Raise<UserNotFound>.fetchUser(id: Long): User {
+  ensure(id > 0) { UserNotFound("Invalid id: $id") }
+  return User(id)
+}
+
+object OtherError
+
+suspend fun Raise<OtherError>.recovery(): User =
+  recover({
+    fetchUser(-1)
+  }) { _: UserNotFound -> raise(OtherError) }

--- a/guide/src/test/kotlin/examples/example-typed-errors-15.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-15.kt
@@ -2,30 +2,25 @@
 package arrow.website.examples.exampleTypedErrors15
 
 import arrow.core.Either
-import arrow.core.Either.Left
-import arrow.core.NonEmptyList
+import arrow.core.left
 import arrow.core.nonEmptyListOf
+import arrow.core.mapOrAccumulate
 import arrow.core.raise.either
 import arrow.core.raise.ensure
-import arrow.core.raise.zipOrAccumulate
+import arrow.core.raise.Raise
 import io.kotest.matchers.shouldBe
 
-sealed interface UserProblem {
-  object EmptyName: UserProblem
-  data class NegativeAge(val age: Int): UserProblem
-}
+data class NotEven(val i: Int)
 
-data class User private constructor(val name: String, val age: Int) {
-  companion object {
-    operator fun invoke(name: String, age: Int): Either<NonEmptyList<UserProblem>, User> = either {
-      zipOrAccumulate(
-        { ensure(name.isNotEmpty()) { UserProblem.EmptyName } },
-        { ensure(age >= 0) { UserProblem.NegativeAge(age) } }
-      ) { _, _ -> User(name, age) }
-    }
-  }
-}
+fun Raise<NotEven>.isEven(i: Int): Int =
+  i.also { ensure(i % 2 == 0) { NotEven(i) } }
+
+fun isEven2(i: Int): Either<NotEven, Int> =
+  either { isEven(i) }
+
+val errors = nonEmptyListOf(NotEven(1), NotEven(3), NotEven(5), NotEven(7), NotEven(9)).left()
 
 fun example() {
-  User("", -1) shouldBe Left(nonEmptyListOf(UserProblem.EmptyName, UserProblem.NegativeAge(-1)))
+  (1..10).mapOrAccumulate { isEven(it) } shouldBe errors
+  (1..10).mapOrAccumulate { isEven2(it).bind() } shouldBe errors
 }

--- a/guide/src/test/kotlin/examples/example-typed-errors-16.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-16.kt
@@ -1,0 +1,28 @@
+// This file was automatically generated from working-with-typed-errors.md by Knit tool. Do not edit.
+package arrow.website.examples.exampleTypedErrors16
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.mapOrAccumulate
+import arrow.core.raise.either
+import arrow.core.raise.ensureNotNull
+import arrow.core.raise.Raise
+import io.kotest.matchers.shouldBe
+
+data class MyError(val message: String)
+
+fun Raise<MyError>.isEven(i: Int): Int =
+  ensureNotNull(i.takeIf { i % 2 == 0 }) { MyError("$i is not even") }
+
+fun isEven2(i: Int): Either<MyError, Int> =
+  either { isEven(i) }
+
+operator fun MyError.plus(second: MyError): MyError =
+  MyError(message + ", ${second.message}")
+
+val error = MyError("1 is not even, 3 is not even, 5 is not even, 7 is not even, 9 is not even").left()
+
+fun example() {
+  (1..10).mapOrAccumulate(MyError::plus) { isEven(it) } shouldBe error
+  (1..10).mapOrAccumulate(MyError::plus) { isEven2(it).bind() } shouldBe error
+}

--- a/guide/src/test/kotlin/examples/example-typed-errors-17.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-17.kt
@@ -1,0 +1,4 @@
+// This file was automatically generated from working-with-typed-errors.md by Knit tool. Do not edit.
+package arrow.website.examples.exampleTypedErrors17
+
+data class User(val name: String, val age: Int)

--- a/guide/src/test/kotlin/examples/example-typed-errors-18.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-18.kt
@@ -1,0 +1,27 @@
+// This file was automatically generated from working-with-typed-errors.md by Knit tool. Do not edit.
+package arrow.website.examples.exampleTypedErrors18
+
+import arrow.core.Either
+import arrow.core.Either.Left
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import io.kotest.matchers.shouldBe
+
+sealed interface UserProblem {
+  object EmptyName: UserProblem
+  data class NegativeAge(val age: Int): UserProblem
+}
+
+data class User private constructor(val name: String, val age: Int) {
+  companion object {
+    operator fun invoke(name: String, age: Int): Either<UserProblem, User> = either {
+      ensure(name.isNotEmpty()) { UserProblem.EmptyName }
+      ensure(age >= 0) { UserProblem.NegativeAge(age) }
+      User(name, age)
+    }
+  }
+}
+
+fun example() {
+  User("", -1) shouldBe Left(UserProblem.EmptyName)
+}

--- a/guide/src/test/kotlin/examples/example-typed-errors-19.kt
+++ b/guide/src/test/kotlin/examples/example-typed-errors-19.kt
@@ -1,0 +1,31 @@
+// This file was automatically generated from working-with-typed-errors.md by Knit tool. Do not edit.
+package arrow.website.examples.exampleTypedErrors19
+
+import arrow.core.Either
+import arrow.core.Either.Left
+import arrow.core.NonEmptyList
+import arrow.core.nonEmptyListOf
+import arrow.core.raise.either
+import arrow.core.raise.ensure
+import arrow.core.raise.zipOrAccumulate
+import io.kotest.matchers.shouldBe
+
+sealed interface UserProblem {
+  object EmptyName: UserProblem
+  data class NegativeAge(val age: Int): UserProblem
+}
+
+data class User private constructor(val name: String, val age: Int) {
+  companion object {
+    operator fun invoke(name: String, age: Int): Either<NonEmptyList<UserProblem>, User> = either {
+      zipOrAccumulate(
+        { ensure(name.isNotEmpty()) { UserProblem.EmptyName } },
+        { ensure(age >= 0) { UserProblem.NegativeAge(age) } }
+      ) { _, _ -> User(name, age) }
+    }
+  }
+}
+
+fun example() {
+  User("", -1) shouldBe Left(nonEmptyListOf(UserProblem.EmptyName, UserProblem.NegativeAge(-1)))
+}

--- a/guide/src/test/kotlin/examples/test/OwnErrorsTest.kt
+++ b/guide/src/test/kotlin/examples/test/OwnErrorsTest.kt
@@ -1,0 +1,15 @@
+// This file was automatically generated from own-error-types.md by Knit tool. Do not edit.
+package arrow.core.examples.test
+
+import io.kotest.core.spec.style.StringSpec
+import arrow.website.captureOutput
+import kotlinx.knit.test.verifyOutputLines
+
+class OwnErrorsTest : StringSpec({
+  "ExampleOwnErrors01" {
+    arrow.website.examples.exampleOwnErrors01.example()
+  }
+
+}) {
+  override fun timeout(): Long = 1000
+}

--- a/guide/src/test/kotlin/examples/test/TypedErrorsTest.kt
+++ b/guide/src/test/kotlin/examples/test/TypedErrorsTest.kt
@@ -46,10 +46,6 @@ class TypedErrorsTest : StringSpec({
     arrow.website.examples.exampleTypedErrors15.example()
   }
 
-  "ExampleTypedErrors16" {
-    arrow.website.examples.exampleTypedErrors16.example()
-  }
-
 }) {
   override fun timeout(): Long = 1000
 }

--- a/guide/src/test/kotlin/examples/test/TypedErrorsTest.kt
+++ b/guide/src/test/kotlin/examples/test/TypedErrorsTest.kt
@@ -6,14 +6,6 @@ import arrow.website.captureOutput
 import kotlinx.knit.test.verifyOutputLines
 
 class TypedErrorsTest : StringSpec({
-  "ExampleTypedErrors01" {
-    arrow.website.examples.exampleTypedErrors01.example()
-  }
-
-  "ExampleTypedErrors02" {
-    arrow.website.examples.exampleTypedErrors02.example()
-  }
-
   "ExampleTypedErrors03" {
     arrow.website.examples.exampleTypedErrors03.example()
   }
@@ -22,12 +14,12 @@ class TypedErrorsTest : StringSpec({
     arrow.website.examples.exampleTypedErrors05.example()
   }
 
-  "ExampleTypedErrors07" {
-    arrow.website.examples.exampleTypedErrors07.example()
+  "ExampleTypedErrors06" {
+    arrow.website.examples.exampleTypedErrors06.example()
   }
 
-  "ExampleTypedErrors08" {
-    arrow.website.examples.exampleTypedErrors08.example()
+  "ExampleTypedErrors07" {
+    arrow.website.examples.exampleTypedErrors07.example()
   }
 
   "ExampleTypedErrors11" {
@@ -38,12 +30,20 @@ class TypedErrorsTest : StringSpec({
     arrow.website.examples.exampleTypedErrors12.example()
   }
 
-  "ExampleTypedErrors14" {
-    arrow.website.examples.exampleTypedErrors14.example()
-  }
-
   "ExampleTypedErrors15" {
     arrow.website.examples.exampleTypedErrors15.example()
+  }
+
+  "ExampleTypedErrors16" {
+    arrow.website.examples.exampleTypedErrors16.example()
+  }
+
+  "ExampleTypedErrors18" {
+    arrow.website.examples.exampleTypedErrors18.example()
+  }
+
+  "ExampleTypedErrors19" {
+    arrow.website.examples.exampleTypedErrors19.example()
   }
 
 }) {


### PR DESCRIPTION
This PR introduces a few improvements to the _typed errors_ section, based on discussions I had with attendees to KotlinConf'23.
- Separates the _Create your own errors_ into its own page, and includes the discussion in #161.
- Makes it more clear what we mean with each term (logical failure, success...).
- More slowly builds the differences between Either/Result/Raise...