### PR TITLE
Schedule renovate bot npm dependecies updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@docusaurus/theme-mermaid": "2.4.0",
         "@easyops-cn/docusaurus-search-local": "0.35.0",
         "@mdx-js/react": "1.6.22",
-        "enhancedocs-chat": "^0.1.3",
+        "enhancedocs-chat": "0.1.3",
         "prism-react-renderer": "1.3.5",
         "react": "17.0.2",
         "react-dom": "17.0.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@docusaurus/theme-mermaid": "2.4.0",
         "@easyops-cn/docusaurus-search-local": "0.35.0",
         "@mdx-js/react": "1.6.22",
-        "enhancedocs-chat": "0.1.3",
+        "enhancedocs-chat": "1.0.0",
         "prism-react-renderer": "1.3.5",
         "react": "17.0.2",
         "react-dom": "17.0.2"
@@ -6975,9 +6975,9 @@
       }
     },
     "node_modules/enhancedocs-chat": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/enhancedocs-chat/-/enhancedocs-chat-0.1.3.tgz",
-      "integrity": "sha512-MTRUQCm2iSDPp51FKmWmZHcK5oYdgB8OgTt08w6vwHCN19sKS+V+ou+DIoCoGIR0kmHtooZssqkocRE4mWGFVg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/enhancedocs-chat/-/enhancedocs-chat-1.0.0.tgz",
+      "integrity": "sha512-Gtt2E8c/KRHSybRsUAdTioKKcudirBNlN7RfC1PTT1ll8EIDSQyvqkcyZibLBWA5VIJ6X4fxgvddVIphkRJkYA==",
       "dependencies": {
         "react-markdown": "^8.0.7"
       },
@@ -21394,9 +21394,9 @@
       }
     },
     "enhancedocs-chat": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/enhancedocs-chat/-/enhancedocs-chat-0.1.3.tgz",
-      "integrity": "sha512-MTRUQCm2iSDPp51FKmWmZHcK5oYdgB8OgTt08w6vwHCN19sKS+V+ou+DIoCoGIR0kmHtooZssqkocRE4mWGFVg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/enhancedocs-chat/-/enhancedocs-chat-1.0.0.tgz",
+      "integrity": "sha512-Gtt2E8c/KRHSybRsUAdTioKKcudirBNlN7RfC1PTT1ll8EIDSQyvqkcyZibLBWA5VIJ6X4fxgvddVIphkRJkYA==",
       "requires": {
         "react-markdown": "^8.0.7"
       }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@docusaurus/theme-mermaid": "2.4.0",
     "@easyops-cn/docusaurus-search-local": "0.35.0",
     "@mdx-js/react": "1.6.22",
-    "enhancedocs-chat": "^0.1.3",
+    "enhancedocs-chat": "0.1.3",
     "prism-react-renderer": "1.3.5",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@docusaurus/theme-mermaid": "2.4.0",
     "@easyops-cn/docusaurus-search-local": "0.35.0",
     "@mdx-js/react": "1.6.22",
-    "enhancedocs-chat": "0.1.3",
+    "enhancedocs-chat": "1.0.0",
     "prism-react-renderer": "1.3.5",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "description": "Group dependencies from package.json files",
+      "matchPaths": ["**/package.json"],
+      "groupName": "All package.json changes",
+      "schedule": [
+        "every 3 months on the first day of the month"
+      ]
+    }
   ]
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -331,3 +331,8 @@ code {
 .theme-back-to-top-button.theme-back-to-top-button::after {
   background-color: var(--ifm-color-primary-darkest);
 }
+
+/* EnhancedChat */
+.EnhancedChat, .EnhancedChat__ChatPopover {
+  left: 20px;
+}

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -1,4 +1,7 @@
 import React, { memo } from 'react';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import EnhancedChat from 'enhancedocs-chat';
 
 import { useThemeConfig, FooterLinkItem } from '@docusaurus/theme-common';
 import FooterLinks from '@theme/Footer/Links';
@@ -7,9 +10,6 @@ import FooterCopyright from '@theme/Footer/Copyright';
 
 import FooterLayout from '@site/src/theme/Footer/Layout';
 import IconLinks from '@site/src/theme/Footer/Links/IconLinks';
-
-// @ts-ignore
-import EnhancedChat from 'enhancedocs-chat';
 
 import 'enhancedocs-chat/dist/style.css';
 
@@ -57,9 +57,20 @@ function Footer(): JSX.Element | null {
 
       <EnhancedChat
         config={{
-          projectId: "6442ad83351c12aba70adc49",
-          accessToken: "pk_6c67a49f78a72d32727881bc42733cbb9da115b85cc1b3d2",
+          projectId: '6442ad83351c12aba70adc49',
+          accessToken: 'pk_6c67a49f78a72d32727881bc42733cbb9da115b85cc1b3d2',
         }}
+        theme={{
+          primaryColor: 'var(--ifm-color-primary)',
+          botName: 'Arrow AI Assistant',
+          logo: {
+            src: '/img/arrow-brand-icon.svg',
+            alt: 'Arrow logo',
+          },
+        }}
+        size="small"
+        shape="square"
+        icon="chat"
       />
     </>
   );


### PR DESCRIPTION
This PR does a couple of things, the most important focusing on reducing a bit the noise created by Renovate bot and npm dependencies. While useful, most of these minor updates aren't worthy of a so continuous update cadence, so once every quarter has been deemed enough to have a look at them.

Besides that, it also pins the `enhancedocs-chat` version number, and it makes the component to appear on the left side of the page, to avoid it conflicting with the go up button that appears when browsing and scrolling the docs section.

* [Adjust renovate bot config batching npm updates](https://github.com/arrow-kt/arrow-website/commit/9fd31ce34987aa0707c858ac17354e56944cd814)
* [Pin dependency version](https://github.com/arrow-kt/arrow-website/commit/02d2d666b6917063b26ed7b55e6a731b0dbb8081)
* [Move EnhancedChat component to left side](https://github.com/arrow-kt/arrow-website/commit/345e978e8aa1dd6e760fcafbd38aa6cde93cab2c)

