### PR TITLE
Explicit name for `it` in `Author` construct

### DIFF
--- a/content/docs/learn/typed-errors/validation.md
+++ b/content/docs/learn/typed-errors/validation.md
@@ -224,9 +224,9 @@ data class Book private constructor(
       zipOrAccumulate(
         { ensure(title.isNotEmpty()) { EmptyTitle } },
         { 
-          val validatedAuthors = mapOrAccumulate(authors.withIndex()) { authorName ->
-            Author(authorName.value)
-              .recover { _ -> raise(EmptyAuthor(authorName.index)) }
+          val validatedAuthors = mapOrAccumulate(authors.withIndex()) { nameAndIx ->
+            Author(nameAndIx.value)
+              .recover { _ -> raise(EmptyAuthor(nameAndIx.index)) }
               .bind()
           }
           ensureNotNull(validatedAuthors.toNonEmptyListOrNull()) { NoAuthors }

--- a/content/docs/learn/typed-errors/validation.md
+++ b/content/docs/learn/typed-errors/validation.md
@@ -224,9 +224,9 @@ data class Book private constructor(
       zipOrAccumulate(
         { ensure(title.isNotEmpty()) { EmptyTitle } },
         { 
-          val validatedAuthors = mapOrAccumulate(authors.withIndex()) {
-            Author(it.value)
-              .recover { _ -> raise(EmptyAuthor(it.index)) }
+          val validatedAuthors = mapOrAccumulate(authors.withIndex()) { authorName ->
+            Author(authorName.value)
+              .recover { _ -> raise(EmptyAuthor(authorName.index)) }
               .bind()
           }
           ensureNotNull(validatedAuthors.toNonEmptyListOrNull()) { NoAuthors }

--- a/guide/src/test/kotlin/examples/example-validation-07.kt
+++ b/guide/src/test/kotlin/examples/example-validation-07.kt
@@ -1,13 +1,10 @@
 // This file was automatically generated from validation.md by Knit tool. Do not edit.
 package arrow.website.examples.exampleValidation07
 
-import arrow.core.left
-import arrow.core.right
 import arrow.core.Either
 import arrow.core.NonEmptyList
 import arrow.core.toNonEmptyListOrNull
 import arrow.core.recover
-import arrow.core.mapOrAccumulate
 import arrow.core.raise.*
 
 sealed interface BookValidationError
@@ -35,10 +32,10 @@ data class Book private constructor(
     ): Either<NonEmptyList<BookValidationError>, Book> = either {
       zipOrAccumulate(
         { ensure(title.isNotEmpty()) { EmptyTitle } },
-        { 
-          val validatedAuthors = mapOrAccumulate(authors.withIndex()) {
-            Author(it.value)
-              .recover { _ -> raise(EmptyAuthor(it.index)) }
+        {
+          val validatedAuthors = mapOrAccumulate(authors.withIndex()) { nameAndIx ->
+            Author(nameAndIx.value)
+              .recover { _ -> raise(EmptyAuthor(nameAndIx.index)) }
               .bind()
           }
           ensureNotNull(validatedAuthors.toNonEmptyListOrNull()) { NoAuthors }

--- a/guide/src/test/kotlin/examples/example-validation-07.kt
+++ b/guide/src/test/kotlin/examples/example-validation-07.kt
@@ -1,10 +1,13 @@
 // This file was automatically generated from validation.md by Knit tool. Do not edit.
 package arrow.website.examples.exampleValidation07
 
+import arrow.core.left
+import arrow.core.right
 import arrow.core.Either
 import arrow.core.NonEmptyList
 import arrow.core.toNonEmptyListOrNull
 import arrow.core.recover
+import arrow.core.mapOrAccumulate
 import arrow.core.raise.*
 
 sealed interface BookValidationError
@@ -32,7 +35,7 @@ data class Book private constructor(
     ): Either<NonEmptyList<BookValidationError>, Book> = either {
       zipOrAccumulate(
         { ensure(title.isNotEmpty()) { EmptyTitle } },
-        {
+        { 
           val validatedAuthors = mapOrAccumulate(authors.withIndex()) { nameAndIx ->
             Author(nameAndIx.value)
               .recover { _ -> raise(EmptyAuthor(nameAndIx.index)) }


### PR DESCRIPTION
When I was reading the doc, I didn't figure out what is the type of `it` easily. I pasted the code into IDE til figured out.
```kotlin
val validatedAuthors = mapOrAccumulate(authors.withIndex()) {
  Author(it.value)
  .recover { _ -> raise(EmptyAuthor(it.index)) }
  .bind()
}
```
I rename `it` explicitly for reduce ambiguity.
```kotlin
val validatedAuthors = mapOrAccumulate(authors.withIndex()) { authorName ->
  Author(authorName.value)
  .recover { _ -> raise(EmptyAuthor(authorName.index)) }
  .bind()
}
```