### PR TITLE
Mention Raise.traced in the Typed Errors page

### DIFF
--- a/content/docs/learn/typed-errors/working-with-typed-errors.md
+++ b/content/docs/learn/typed-errors/working-with-typed-errors.md
@@ -426,6 +426,12 @@ fun problematic(n: Int): Either<Problem, Int?> =
 
 :::
 
+::: info Tracing the origin of a raise
+
+As projects grow in size, raised errors propagate through the call stack. To make debugging easier, Arrow provides a way to trace calls to `raise` and `bind`: [see Raise.traced](https://apidocs.arrow-kt.io/arrow-core/arrow.core.raise/traced.html).
+
+:::
+
 ## Recovering from typed errors
 
 We've already hinted this distinction above, but with working with type errors it's important to distinguish between two kinds of _problems_ that may arise:


### PR DESCRIPTION
> Issue: #245 

I believe `traced` is sufficiently well explained in the API docs that it's not worth adding an entire paragraph to the main documentation, and a simple mention is enough (for discoverability / for users who know it exists but do not know where to find it).

Therefore, this PR adds a short information note to the "Running and inspecting results" mentioning the feature.