### PR TITLE
Fix rendering of info block on "Working with typed errors"

### DIFF
--- a/content/docs/learn/typed-errors/working-with-typed-errors.md
+++ b/content/docs/learn/typed-errors/working-with-typed-errors.md
@@ -426,7 +426,7 @@ fun problematic(n: Int): Either<Problem, Int?> =
 
 :::
 
-::: info Tracing the origin of a raise
+:::info Tracing the origin of a raise
 
 As projects grow in size, raised errors propagate through the call stack. To make debugging easier, Arrow provides a way to trace calls to `raise` and `bind`: [see Raise.traced](https://apidocs.arrow-kt.io/arrow-core/arrow.core.raise/traced.html).
 


### PR DESCRIPTION
https://arrow-kt.io/learn/typed-errors/working-with-typed-errors/#running-and-inspecting-results

<img width="1109" alt="Screenshot 2024-03-08 at 19 26 29" src="https://github.com/arrow-kt/arrow-website/assets/2178959/81edd03c-f1cc-421d-9a9f-c21a1a151b7e">
