### PR TITLE
Fix mermaid parsing error

### DIFF
--- a/content/docs/learn/immutable-data/intro.md
+++ b/content/docs/learn/immutable-data/intro.md
@@ -153,13 +153,13 @@ Arrow 2.x simplifies the hierarchy to the five optics described in this section.
 
 ```mermaid
 graph TD;
-  subgraph <h4>only access</h4>
+  subgraph "<h4>only access</h4>"
     fold{{"<b>Fold</b> (0 .. ∞)<br /><tt>getAll</tt>"}};
     optionalFold{{"<b>OptionalFold</b> (0 .. 1)<br /><tt>getOrNull</tt>"}};
     getter{{"<b>Getter</b> (exactly 1)<br /><tt>get</tt>"}};
   end
   setter{{"<b>Setter</b><br /><tt>modify</tt> and <tt>set</tt>"}};
-  subgraph <h4>Arrow 2.x</h4>
+  subgraph "<h4>Arrow 2.x</h4>"
     traversal{{"<b>Traversal</b>"}};
     optional{{"<b>Optional</b>"}};
     lens{{"<b>Lens</b>"}};


### PR DESCRIPTION
I don't know why or since when, but the diagram on https://arrow-kt.io/learn/immutable-data/intro/ was broken.
I experimented on mermaid playground and found that surrounding the text in quotes resulted in correct html element.

![image](https://github.com/arrow-kt/arrow-website/assets/8557044/7e6e152e-f950-4155-9d6e-e7e46b58174e)