### PR TITLE
Mention ArrowModule in serialization and ktor sections

### DIFF
--- a/content/docs/learn/integrations.md
+++ b/content/docs/learn/integrations.md
@@ -80,7 +80,7 @@ importing the serializers with `@UseSerializers`.
 
 If you want to use Arrow Core types directly as your request or response models, you will need to include the `ArrowModule` in your serializers module:
 
-```kotlin
+```
 install(ContentNegotiation) {
   json(Json {
     serializersModule = ArrowModule
@@ -92,7 +92,7 @@ If you're using Jackson, you can use the
 [custom mapper](https://github.com/arrow-kt/arrow-integrations#ktor),
 and pass it to the `ContentNegotiation` configuration.
 
-```kotlin
+```
 install(ContentNegotiation) {
   register(ContentType.Application.Json, JacksonConverter(JsonMapper.mapper))
 }

--- a/content/docs/learn/integrations.md
+++ b/content/docs/learn/integrations.md
@@ -78,6 +78,16 @@ The main point of contact between Ktor and Arrow is in
 If you're using kotlinx.serialization, you need no further changes other than
 importing the serializers with `@UseSerializers`.
 
+If you want to use Arrow Core types directly as your request or response models, you will need to include the `ArrowModule` in your serializers module:
+
+```kotlin
+install(ContentNegotiation) {
+  json(Json {
+    serializersModule = ArrowModule
+  })
+}
+```
+
 If you're using Jackson, you can use the
 [custom mapper](https://github.com/arrow-kt/arrow-integrations#ktor),
 and pass it to the `ContentNegotiation` configuration.

--- a/content/docs/learn/quickstart/serialization.md
+++ b/content/docs/learn/quickstart/serialization.md
@@ -20,7 +20,7 @@ If you're using kotlinx.serialization, you need to depend on the
 Declare your serializable types as usual. However, when one of the fields
 mentions a type from Arrow Core,
 
-```kotlin
+```
 @Serializable
 data class Book(val title: String, val authors: NonEmptyList<String>)
 ```
@@ -28,7 +28,7 @@ data class Book(val title: String, val authors: NonEmptyList<String>)
 you need to "import" the serializer into the file. The easiest way is to
 include a `UseSerializers` annotation at the very top.
 
-```kotlin
+```
 @file:UseSerializers(
   EitherSerializer::class,
   IorSerializer::class,
@@ -44,19 +44,19 @@ kotlinx.serialization plug-in gives you an error.
 
 Additionally, you can use `arrow.core.serialization.ArrowModule` to register run-time [contextual serialization](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#contextual-serialization) support of the Arrow Core types. 
 
-```kotlin
+```
 val format = Json { serializersModule = ArrowModule }
 ```
 
 or by merging with another serializers module
 
-```kotlin
+```
 val format = Json { serializersModule = myModule + ArrowModule }
 ```
 
 This will allow for use of the Arrow Core types as the value to be serialized without specifying the serializer explicitly:
 
-```kotlin
+```
 val payload = format.encodeToString(nonEmptyListOf("hello", "world"))
 ```
 
@@ -80,7 +80,7 @@ If you're using Jackson for serialization, [this module](https://github.com/arro
 adds support for Arrow types. You just need to call an additional method when
 creating the mapper.
 
-```kotlin
+```
 val mapper = ObjectMapper()
     .registerKotlinModule()
     .registerArrowModule()   // <- this is the one

--- a/content/docs/learn/quickstart/serialization.md
+++ b/content/docs/learn/quickstart/serialization.md
@@ -20,7 +20,7 @@ If you're using kotlinx.serialization, you need to depend on the
 Declare your serializable types as usual. However, when one of the fields
 mentions a type from Arrow Core,
 
-```
+```kotlin
 @Serializable
 data class Book(val title: String, val authors: NonEmptyList<String>)
 ```
@@ -28,11 +28,10 @@ data class Book(val title: String, val authors: NonEmptyList<String>)
 you need to "import" the serializer into the file. The easiest way is to
 include a `UseSerializers` annotation at the very top.
 
-```
+```kotlin
 @file:UseSerializers(
   EitherSerializer::class,
   IorSerializer::class,
-  ValidatedSerializer::class,
   OptionSerializer::class,
   NonEmptyListSerializer::class,
   NonEmptySetSerializer::class
@@ -42,6 +41,30 @@ include a `UseSerializers` annotation at the very top.
 The list above mentions all the serializers, but you only need to add those
 which are used in your fields. Don't worry too much: if you miss one, the
 kotlinx.serialization plug-in gives you an error.
+
+Additionally, you can use `arrow.core.serialization.ArrowModule` to register run-time [contextual serialization](https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serializers.md#contextual-serialization) support of the Arrow Core types. 
+
+```kotlin
+val format = Json { serializersModule = ArrowModule }
+```
+
+or by merging with another serializers module
+
+```kotlin
+val format = Json { serializersModule = myModule + ArrowModule }
+```
+
+This will allow for use of the Arrow Core types as the value to be serialized without specifying the serializer explicitly:
+
+```kotlin
+val payload = format.encodeToString(nonEmptyListOf("hello", "world"))
+```
+
+:::note
+
+Using `@UseSerializers` to provide static _compile-time_ serialization of fields containing Arrow Core types is usually preferable to annotating fields with `@Contextual` and relying on _run-time_ resolution, wherever possible.
+
+:::
 
 :::info Additional reading
 


### PR DESCRIPTION
Given the `ArrowModule` is currently only in the 2.0 branch, I would assume this will need to wait until the 2.0 release. As such, I've also removed the reference to `ValidatedSerializer`. 