### PR TITLE
Fix (presumed)Typo in Front Page Quickstart Card

### DIFF
--- a/src/pages/index.yml
+++ b/src/pages/index.yml
@@ -13,7 +13,7 @@ features:
     href: /learn/quickstart
     icon: icon-quickstart.svg
     # body: Backend or frontend, JVM, Android or Multiplatform, Gradle or Maven, Arrow fits in all your projects
-    body: "Learn how Arrow can help you write better Kotlin code faster — backend of frontend, JVM, Android or Multiplatform"
+    body: "Learn how Arrow can help you write better Kotlin code faster — backend or frontend, JVM, Android or Multiplatform"
 
   - title: Typed errors
     href: /learn/typed-errors


### PR DESCRIPTION
I'm assuming this is a typo rather than a reference to the "backend for frontend" application design structure.


<img width="740" height="507" alt="Screenshot 2026-04-16 at 11 17 47 AM" src="https://github.com/user-attachments/assets/006e6b7c-a505-4eb3-8386-54d5c1ac4903" />
