### PR TITLE
Draft • Use context parameters everywhere!

### DIFF
--- a/content/docs/learn/quickstart/from-fp.md
+++ b/content/docs/learn/quickstart/from-fp.md
@@ -113,6 +113,36 @@ fun mkPerson(name: String, age: Int): Either<Problem, Person> = either {
 ```
 <!--- KNIT example-scala-migration-02.kt -->
 
+The `either` block allows its content to raise errors and short-circuits when that happens.
+Using this style, every function creates its own `Either` wrapper for its result, which is immediately unwrapped by the caller
+so it can create its own wrapper with its own result. Instead, if all functions _declare that they may fail_, the failure 
+can short-circuit without needing wrappers until the place where it is handled (for example, by wrapping it into an `Either`).
+
+To declare errors without wrapping, we use the `Raise` effect:
+<!--- INCLUDE
+import arrow.core.*
+import arrow.core.raise.either
+
+data class Person(val name: String, val age: Int)
+interface Problem
+-->
+
+```kotlin
+context(raise: Raise<Problem>)
+fun validName(name: String): String = TODO()
+
+context(raise: Raise<Problem>)
+fun validAge(age: Int): Int = TODO()
+
+context(raise: Raise<Problem>)
+fun mkPerson(name: String, age: Int): Person = 
+  Person(validName(name), validAge(age))
+```
+<!--- KNIT example-scala-migration-02b.kt -->
+
+When all functions are declared to raise, they can simply be called within each other with no additional syntax.
+To get an `Either` from any such function, we call it within the `either` block.
+
 :::tip No zip
 
 It's common to use functions like `zip` to combine values inside a 
@@ -127,7 +157,7 @@ except when [dealing with concurrency](../../coroutines/parallel/).
 If you want to apply an effectful operation to every element of a collection,
 you need to use a function different from `map`, usually called `traverse`.
 This split does not exist in Arrow: you can use the same functions you know
-and love from the collections API inside one of these blocks.
+and love from the collections API inside `either` or `Raise`.
 
 :::
 

--- a/content/docs/learn/quickstart/index.md
+++ b/content/docs/learn/quickstart/index.md
@@ -36,16 +36,17 @@ and also extra safety, as the compiler will ensure that you don't forget to hand
   <TabItem value="typedErrors1Example" label="Show me the code">
 
   ```kotlin
-  // these signatures mark the possible errors
-  suspend fun findUser(id: UserId): Either<UserNotFound, User> { TODO() }
+  // this function declares it may fail with UserNotFound
+  context(raise: Raise<UserNotFound>)
+  suspend fun findUser(id: UserId): User { TODO() }
   
-  // you build larger computations using the 'Raise' DSL
-  suspend fun fromTheSameCity(id1: UserId, id2: UserId): Either<UserNotFound, Boolean> =
-    either {  // this begins a 'Raise' block
-      val user1 = findUser(id1).bind()  // 'bind' aborts computation on failure
-      val user2 = findUser(id2).bind()
+  // you build larger computations as usual, no added syntax!
+  context(raise: Raise<UserNotFound>)
+  suspend fun fromTheSameCity(id1: UserId, id2: UserId): Boolean {
+      val user1 = findUser(id1)  // no need for any operator, no 'bind', no nested flatMap…
+      val user2 = findUser(id2)  // …just regular function calls!
       return user1.city == user2.city
-    }
+  }
   ```
 
   </TabItem>
@@ -61,13 +62,12 @@ This is especially useful when validating user input, as you often want to repor
   <TabItem value="typedErrors2Example" label="Show me the code">
 
 ```kotlin
-fun buildUser(name: String, age: Int): Either<NonEmptyList<UserProblem>, User> = 
-  either {
-    accumulate {
-      ensureOrAccumulate(name.isNotEmpty()) { UserProblem.EmptyName }
-      ensureOrAccumulate(age >= 0) { UserProblem.NegativeAge(age) }
-      User(name, age)
-    }
+context(raise: Raise<NonEmptyList<UserProblem>>)
+fun buildUser(name: String, age: Int): User = 
+  accumulate {
+    ensureOrAccumulate(name.isNotEmpty()) { UserProblem.EmptyName }
+    ensureOrAccumulate(age >= 0) { UserProblem.NegativeAge(age) }
+    User(name, age)
   }
 ```
 


### PR DESCRIPTION
Nowadays, errors-as-effects is the approach we recommend when writing code with Arrow. This PR will align the documentation to this approach, mentioning errors-as-values in a specific section of the Typed Errors docs instead of being in every example everywhere.